### PR TITLE
Ignore missing payment operation in pending render

### DIFF
--- a/pretix_quickpay/payment.py
+++ b/pretix_quickpay/payment.py
@@ -221,10 +221,11 @@ class QuickpayMethod(BasePaymentProvider):
         else:
             payment_info = None
         template = get_template("pretix_quickpay/pending.html")
+        operations = payment_info.get("operations", [])
         ctx = {
             "payment_info": payment_info,
             "payment": payment,
-            "operation": payment_info.get("operations")[-1],
+            "operation": operations[-1] if len(operations) > 0 else None,
         }
         return template.render(ctx)
 


### PR DESCRIPTION
Hey there!

It seems that creating an order, starting a QuickPay payment (e.g. with Swish) and then cancelling it immediately causes the order overview page to break on `IndexError: list index out of range` as the `payment.info["operations"]` can be an empty list.

This PR correctly handles this case, and additionally safe guards against the `operations` key missing completely.

Please let me know what you think 🥳